### PR TITLE
Add metric for number of pending messages

### DIFF
--- a/com.ibm.streamsx.kafka/impl/java/src/com/ibm/streamsx/kafka/operators/AbstractKafkaConsumerOperator.java
+++ b/com.ibm.streamsx.kafka/impl/java/src/com/ibm/streamsx/kafka/operators/AbstractKafkaConsumerOperator.java
@@ -107,6 +107,13 @@ public abstract class AbstractKafkaConsumerOperator extends AbstractKafkaOperato
         this.nMalformedMessages = nMalformedMessages;
     }
 
+    private Metric nPendingMessages;
+
+    @CustomMetric (kind = Metric.Kind.GAUGE, description = "Number of pending messages to be submitted as tuples.")
+    public void setnPendingMessages(Metric nPendingMessages) {
+        this.nPendingMessages = nPendingMessages;
+    }
+
 
     @Parameter(optional = true, name=OUTPUT_TIMESTAMP_ATTRIBUTE_NAME_PARAM,
     		description="Specifies the output attribute name that should contain the record's timestamp. "


### PR DESCRIPTION
In trying to understand the performance of the consumer it was painful not being able to understand how many messages were pending in the `KafkaConsumer` (or `MessageHubConsumer`) operator (in its `messageQueue`).

![image](https://user-images.githubusercontent.com/3769612/40082225-37ddb0b2-5845-11e8-97a6-1c704e4ed780.png)
